### PR TITLE
Additional updates for Docker, requires PowerShell 5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,6 @@ node ('w10e2') {
     stage ('Clean Previous Run') {
       bat "IF EXIST .vagrant vagrant destroy -f"
       bat "IF EXIST .vagrant vagrant box list"
-      bat "IF EXIST .vagrant vagrant box update"
       bat "IF EXIST windows-master RMDIR /S /Q windows-master"
     }
     

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |allhosts|
       override.vm.boot_timeout = 600
       override.vm.communicator = 'winrm'
       virtualbox.gui = false
-      override.vm.network 'private_network', ip: '172.16.17.101'
+      override.vm.network 'private_network', ip: '10.10.8.101'
       override.vm.network 'forwarded_port', guest: 3389, host: 13389 # Remote Desktop
       override.vm.network 'forwarded_port', guest: 5985, host: 15985 # WinRM HTTP
       override.vm.network 'forwarded_port', guest: 5986, host: 15986 # WinRM HTTPS

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+#> vagrant plugin install vagrant-reload
+require 'vagrant-reload'
+
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
@@ -14,7 +17,11 @@ Vagrant.configure(2) do |allhosts|
     host.vm.provision 'shell', path: './automation/remote/capabilities.ps1'
     host.vm.provision 'shell', path: './automation/provisioning/mkdir.ps1', args: 'C:\deploy'
     host.vm.provision 'shell', path: './automation/provisioning/mkdir.ps1', args: 'C:\deploy'
+    host.vm.provision 'shell', path: './automation/provisioning/applyWindowsUpdates.ps1'
+    host.vm.provision :reload
     host.vm.provision 'shell', path: './automation/provisioning/installDocker.ps1'
+    host.vm.provision 'shell', path: './automation/provisioning/applyWindowsUpdates.ps1'
+    host.vm.provision :reload
     
     host.vm.provider 'virtualbox' do |virtualbox, override|
       override.vm.box = 'mwrock/Windows2016'

--- a/automation/CDAF.windows
+++ b/automation/CDAF.windows
@@ -1,5 +1,5 @@
 # Do not make customisation or configuration changes in these folders, copy the solution folder 
 # and apply configuration changes that are specific to your solution.
-productVersion=1.5.1.03
+productVersion=1.5.1.05
 productName=Continuous Delivery Automation Framework
 solutionName=WU-CDM

--- a/automation/CDAF.windows
+++ b/automation/CDAF.windows
@@ -1,5 +1,5 @@
 # Do not make customisation or configuration changes in these folders, copy the solution folder 
 # and apply configuration changes that are specific to your solution.
-productVersion=1.5.1.02
+productVersion=1.5.1.03
 productName=Continuous Delivery Automation Framework
 solutionName=WU-CDM

--- a/automation/CDAF.windows
+++ b/automation/CDAF.windows
@@ -1,5 +1,5 @@
 # Do not make customisation or configuration changes in these folders, copy the solution folder 
 # and apply configuration changes that are specific to your solution.
-productVersion=1.5.1.01
+productVersion=1.5.1.02
 productName=Continuous Delivery Automation Framework
 solutionName=WU-CDM

--- a/automation/provisioning/SQLServer.ps1
+++ b/automation/provisioning/SQLServer.ps1
@@ -96,12 +96,26 @@ $argList = @(
 	'/SQLSVCSTARTUPTYPE="Automatic"',
 	'/SQLCOLLATION="SQL_Latin1_General_CP1_CI_AS"',
 	"/SQLSVCACCOUNT=`"$serviceAccount`"",
-	"/SQLSVCPASSWORD=$password",
+	"/SQLSVCPASSWORD=`"$password`"",
 	"/SQLSYSADMINACCOUNTS=`"$adminAccount`"",
 	'/TCPENABLED=1',
 	'/NPENABLED=1'
 )
 Write-Host
 executeExpression "`$proc = Start-Process -FilePath `"$media$executable`" -ArgumentList `'$argList`' $sessionControl"
+
+foreach ( $sqlVersions in Get-ChildItem "C:\Program Files\Microsoft SQL Server\" ) {
+	$logPath = $sqlVersions.FullName + '\Setup Bootstrap\Log\Summary.txt'
+	if ( Test-Path $logPath ) {
+		$result = cat $logPath | findstr "Failed:"
+		if ($result) {
+			Write-Host
+		    Write-Host "[$scriptName] `'Failed:`' found in $logPath, first 40 lines follow ..."
+			Get-Content $logPath | select -First 40
+		}
+	} 
+}
+
+
 Write-Host
 Write-Host "[$scriptName] ---------- stop ----------"

--- a/automation/provisioning/WebDeploy.ps1
+++ b/automation/provisioning/WebDeploy.ps1
@@ -3,10 +3,11 @@ function executeExpression ($expression) {
 	$error.clear()
 	Write-Host "[$scriptName] $expression"
 	try {
-		Invoke-Expression $expression
+		$output = Invoke-Expression $expression
 	    if(!$?) { Write-Host "[$scriptName] `$? = $?"; exit 1 }
 	} catch { echo $_.Exception|format-list -force; exit 2 }
     if ( $error[0] ) { Write-Host "[$scriptName] `$error[0] = $error"; exit 3 }
+    return $output
 }
 
 $scriptName = 'WebDeploy.ps1'
@@ -127,10 +128,10 @@ $key = "HKLM:\SOFTWARE\Microsoft\IIS Extensions\MSDeploy\$installPath"
 $name = 'InstallPath'
 
 # Retrieve the install path from the registry key, if missing, halt with error
-executeExpression "`$InstallPath = (Get-ItemProperty -Path `'$key`' -Name $name).$name"
+$InstallPath = executeExpression "(Get-ItemProperty -Path `'$key`' -Name $name).$name"
 
 write-host "Set environment variable MSDeployPath to $InstallPath"
-[Environment]::SetEnvironmentVariable('MSDeployPath', "$InstallPath", 'User')
+executeExpression "[Environment]::SetEnvironmentVariable('MSDeployPath', `'$InstallPath`', `'Machine`')"
 
 Write-Host
 Write-Host "[$scriptName] ---------- stop ----------"

--- a/automation/provisioning/applyWindowsUpdates.ps1
+++ b/automation/provisioning/applyWindowsUpdates.ps1
@@ -24,15 +24,12 @@ function executeExpression ($expression) {
     }
 }
 
-# Only from Windows Server 2016 and above
+# Only for Windows Server 2016 and above
 $scriptName = 'installDocker.ps1'
 Write-Host
 Write-Host "[$scriptName] ---------- start ----------"
 
-# Requires KB3176936
-
-executeExpression  "Install-Module -Name DockerMsftProvider -Repository PSGallery -Force -Confirm:`$False"
-executeExpression  "Install-Package -Name docker -ProviderName DockerMsftProvider -Force -Confirm:`$False"
+executeExpression  "Get-WUInstall –Verbose –AcceptAll –AutoReboot:`$False -Confirm:`$False"
 
 Write-Host
 Write-Host "[$scriptName] ---------- stop ----------"

--- a/automation/provisioning/installDocker.ps1
+++ b/automation/provisioning/installDocker.ps1
@@ -32,6 +32,7 @@ Write-Host "[$scriptName] ---------- start ----------"
 # Requires KB3176936
 
 executeExpression  "Install-Module -Name DockerMsftProvider -Repository PSGallery -Force -Confirm:`$False"
+executeExpression  "Enable-WindowsOptionalFeature -Online -FeatureName Containers -All"
 executeExpression  "Install-Package -Name docker -ProviderName DockerMsftProvider -Force -Confirm:`$False"
 
 Write-Host

--- a/automation/provisioning/installDocker.ps1
+++ b/automation/provisioning/installDocker.ps1
@@ -24,12 +24,23 @@ function executeExpression ($expression) {
     }
 }
 
+# Only from Windows Server 2016 and above
 $scriptName = 'installDocker.ps1'
 Write-Host
 Write-Host "[$scriptName] ---------- start ----------"
 
+# From https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/quick-start-windows-server
+
 executeExpression  "Install-Module -Name DockerMsftProvider -Repository PSGallery -Force"
 executeExpression  "Install-Package -Name docker -ProviderName DockerMsftProvider -Force"
+
+# From https://marckean.com/2016/06/01/use-powershell-to-install-windows-updates/
+
+executeExpression  "Install-Module PSWindowsUpdate"
+executeExpression  "Get-Command –module PSWindowsUpdate"
+
+executeExpression  "Add-WUServiceManager -ServiceID 7971f918-a847-4430-9279-4a52d1efe18d"
+executeExpression  "Get-WUInstall –MicrosoftUpdate –AcceptAll –AutoReboot"
 
 Write-Host
 Write-Host "[$scriptName] ---------- stop ----------"


### PR DESCRIPTION
Additional updates for Docker, requires PowerShell 5 (which, as Docker is only available on Windows Server 2016, is inherently
satisfiead)
