### PR TITLE
Apply active error trap in log watcher (requires latest CDAF)

### DIFF
--- a/.cdaf/customLocal/compose.ps1
+++ b/.cdaf/customLocal/compose.ps1
@@ -1,0 +1,28 @@
+Param (
+	[string]$command
+)
+
+$scriptName = 'compose.ps1'
+
+function executeWarning ($expression) {
+	$error.clear()
+	Write-Host "[$(date)] $expression"
+	try {
+		Invoke-Expression $expression
+	    if(!$?) { Write-Host "[$scriptName] `$? = $?"; exit 1 }
+	} catch { Write-Host $_.Exception | format-list -force; exit 2 }
+    if ( $error ) { foreach ( $out in $error ) { Write-Host "[WARN][$scriptName] $out" }; $error.clear() }
+    if (( $LASTEXITCODE ) -and ( $LASTEXITCODE -ne 0 )) { Write-Host "[$scriptName] `$LASTEXITCODE = $LASTEXITCODE "; exit $LASTEXITCODE }
+}
+
+cmd /c "exit 0"
+Write-Host "`n[$scriptName] ---------- start ----------"
+if ( $command ) {
+	executeWarning "$command 2> trap.log"
+} else {
+	executeWarning "docker-compose down --remove-orphans 2> trap.log"
+	executeWarning "docker-compose rm -f 2> trap.log"
+}
+
+Write-Host "`n[$scriptName] ---------- stop ----------"
+exit 0

--- a/.cdaf/customLocal/compose.tsk
+++ b/.cdaf/customLocal/compose.tsk
@@ -1,32 +1,35 @@
 $workspace = "$(pwd)"
+if ( $retain ) { $env:COMPOSE_KEEP = $retain }
 
-Write-Host "Each environment has it's own persistent store (/$SOLUTION/$environment) to ensure teardown based on the compose file they were created with`n"
-MAKDIR "/$SOLUTION/$environment"
+$composePersist = "/$SOLUTION/$environment"
+Write-Host "Each environment has it's own persistent store (${composePersist}) to ensure teardown based on the compose file they were created with`n"
+MAKDIR "${composePersist}"
 
 Write-Host "`n[$scriptName] Set port for testing`n"
 if ( ! ( $publishedPort )) { $publishedPort = 8000 }
 $env:CBE_PORT = ./nextFreePort.ps1 $publishedPort
 
-Write-Host "Test for existing instance`n"
-cd "/$SOLUTION/$environment"
+VECOPY .\compose.ps1 $composePersist
+cd "${composePersist}"
 
-Write-Host "Place the current version of compose file to persistent store (/$SOLUTION/$environment)`n"
-VECOPY ${workspace}\docker-compose.yml "/$SOLUTION/$environment/docker-compose.yml"
+Write-Host "Place the current version of compose file to persistent store (${composePersist})`n"
+VECOPY ${workspace}\docker-compose.yml "${composePersist}/docker-compose.yml"
 
-cat "/$SOLUTION/$environment/docker-compose.yml"
+cat "${composePersist}/docker-compose.yml"
 
 $env:CORE_IMAGE = "${SOLUTION}"
-docker-compose down
-docker-compose rm
+.\compose.ps1
 
 $env:CORE_IMAGE = "${SOLUTION}:$BUILDNUMBER"
-docker-compose up -d
+.\compose.ps1 'docker-compose up -d'
 
 Write-Host "Wait up to 5 minutes for migrations`n"
 & ${workspace}\dockerLog.ps1 DOCKER-COMPOSE runserver 300
 
 Write-Host "Test on `$env:CBE_PORT $env:CBE_PORT`n"
 & ${workspace}\test.ps1 $env:CBE_PORT
+
+if ( $env:COMPOSE_KEEP ) { docker inspect -f '{{.Name}} - {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -aq) } else { .\compose.ps1 }
 
 Write-Host "Return to `$workspace $workspace`n"
 cd $workspace

--- a/.cdaf/propertiesForLocalTasks/BAMBOO_FORK.Z
+++ b/.cdaf/propertiesForLocalTasks/BAMBOO_FORK.Z
@@ -1,2 +1,3 @@
 # Launch instances, need to set DOCKER_HOST if remote containers
 deployTaskOverride=cleanTarget.tsk
+retain=yes

--- a/.cdaf/propertiesForLocalTasks/PROD
+++ b/.cdaf/propertiesForLocalTasks/PROD
@@ -1,3 +1,0 @@
-# Launch instances, need to set DOCKER_HOST if remote containers
-deployTaskOverride=compose.tsk
-environment=prod

--- a/.cdaf/propertiesForLocalTasks/PROD.Z
+++ b/.cdaf/propertiesForLocalTasks/PROD.Z
@@ -1,2 +1,0 @@
-# Launch instances, need to set DOCKER_HOST if remote containers
-deployTaskOverride=cleanTarget.tsk

--- a/.cdaf/propertiesForLocalTasks/TEST.8001
+++ b/.cdaf/propertiesForLocalTasks/TEST.8001
@@ -1,4 +1,0 @@
-# Launch instances, need to set DOCKER_HOST if remote containers
-deployTaskOverride=compose.tsk
-environment=test
-publishedPort=8001

--- a/start.ps1
+++ b/start.ps1
@@ -6,10 +6,10 @@ function executeExpression ($expression) {
 	Write-Host "[$scriptName] $expression"
 	try {
 		Invoke-Expression $expression
-	    if(!$?) { Write-Host "[$scriptName] `$? = $?"; exit 1 }
-	} catch { echo $_.Exception|format-list -force; exit 2 }
-    if ( $error[0] ) { Write-Host "[$scriptName] `$error[0] = $error"; exit 3 }
-    if (( $LASTEXITCODE ) -and ( $LASTEXITCODE -ne 0 )) { Write-Host "[$scriptName] `$LASTEXITCODE = $LASTEXITCODE "; exit $LASTEXITCODE }
+	    if(!$?) { Write-Host "[$scriptName][CDAF_DELIVERY_FAILURE.FAILURE] `$? = $?"; exit 1 }
+	} catch { Write-Host "[$scriptName][CDAF_DELIVERY_FAILURE.EXCEPTION] Details follow ..." ; echo $_.Exception|format-list -force; exit 2 }
+    if ( $error[0] ) { Write-Host "[$scriptName][CDAF_DELIVERY_FAILURE.ERROR] `$error[0] = $error"; exit 3 }
+    if (( $LASTEXITCODE ) -and ( $LASTEXITCODE -ne 0 )) { Write-Host "[$scriptName][CDAF_DELIVERY_FAILURE.EXIT] `$LASTEXITCODE = $LASTEXITCODE "; exit $LASTEXITCODE }
 }
 
 Write-Host "`n[$scriptName] ---------- start ----------`n"


### PR DESCRIPTION
This does not fix the migration issue, but actively traps it rather than waiting to time out.